### PR TITLE
Add file open 'rb' mode to Attachment example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -103,7 +103,7 @@ It is quite easy to add attachments, we need :class:`Attachment` instance::
     
     from sender import Attachment
 
-    with open("logo.jpg") as f:
+    with open("logo.jpg", "rb") as f:
         attachment = Attachment("logo.jpg", "image/jpeg", f.read())
 
     msg.attach(attachment)


### PR DESCRIPTION
This PR adds `'rb'` to the Attachment example's `open()` call. Without this mode, Python attempts to decode image attachment contents as text and fails with:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```